### PR TITLE
tab-link js

### DIFF
--- a/js/tabLink.js
+++ b/js/tabLink.js
@@ -1,0 +1,7 @@
+$(function(){
+    var activeTab = document.querySelector(location.hash);
+    console.log(activeTab)
+    if (activeTab){
+        activeTab.click();
+    }
+});

--- a/outros/downloads.html
+++ b/outros/downloads.html
@@ -684,6 +684,7 @@
 			<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 			<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 			<script src="../js/sidenav.js"></script>
+			<script src="../js/tabLink.js"></script>
 		</footer>
 	</body>
 </html>


### PR DESCRIPTION
arquivo javascript que faz a selecao de uma tab do menu quando selecionado por link externo. Ele foi incluido nos donwloads. Se for feito, por exemplo, downloads.html#escolab-tab, vai ser redirecionado para a tab do escolab automaticamente.