### PR TITLE
um link do manual

### DIFF
--- a/manual/index.html
+++ b/manual/index.html
@@ -86,7 +86,7 @@
 						<a class="nav-link" href="../#maisprojetos">Mais Projetos</a>
 				    </li>
 				    <li class="nav-item">
-				  		<a class="nav-link" href="../#downloads">Downloads</a>
+				  		<a class="nav-link" href="../downloads">Downloads</a>
 				    </li>
 				</ul>
 			  </div>


### PR DESCRIPTION
O link de downloads a partir do manual tinha um # a mais por engano. Agora está correto.